### PR TITLE
Updated the date time format string to ISO 8601 format.

### DIFF
--- a/Harvest.Api/Shared/RequestBuilder.cs
+++ b/Harvest.Api/Shared/RequestBuilder.cs
@@ -14,7 +14,7 @@ namespace Harvest.Api
     class RequestBuilder
     {
         private const string AccountIdHeader = "Harvest-Account-Id";
-        private const string DateFormat = "yyyy-MM-dd";
+        private const string DateFormat = "yyyy-MM-ddTHH:mm:ssZ";
         private readonly static JsonSerializer _serializer;
         internal const string JsonMimeType = "application/json";
 


### PR DESCRIPTION
Per Harvest docs, datetimes are in ISO 8601 format. The old date format string truncated the time portion. This causes issues when listing entries by last updated as well as creating or updating an entry's started or ended times.

Those are the two instances I ran into, there may be more.